### PR TITLE
Winit 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ backend-sympal = ["dep:cpal"]
 default = ["media-controls", "tui", "clipboard", "backend-sympal", "backend-rodio"]
 
 [target.'cfg(windows)'.dependencies]
-winit = {version = "0.29", features = ['rwh_05']}
+winit = {version = "0.29", default-features = false, features = ["rwh_05", "x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]}
 
 [profile.dev]
 opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ backend-sympal = ["dep:cpal"]
 default = ["media-controls", "tui", "clipboard", "backend-sympal", "backend-rodio"]
 
 [target.'cfg(windows)'.dependencies]
+raw-window-handle = "0.5"
 winit = {version = "0.29", default-features = false, features = ["rwh_05", "x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]}
 
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ backend-sympal = ["dep:cpal"]
 default = ["media-controls", "tui", "clipboard", "backend-sympal", "backend-rodio"]
 
 [target.'cfg(windows)'.dependencies]
-winit = {version = "0.29", features = ['rwh_06']}
+winit = {version = "0.29", features = ['rwh_05']}
 
 [profile.dev]
 opt-level = 1

--- a/src/main.rs
+++ b/src/main.rs
@@ -814,23 +814,18 @@ fn instance_main(listener: TcpListener, args: Args) {
                     // You *could* use winapi::um::wincon::GetConsoleWindow()
                     // but if you're running ompl from the CLI, conhost.exe will own the window process
                     // so souvlaki can't hook into it. This just creates a hidden window instead.
-                    use winit::raw_window_handle::{HasWindowHandle, RawWindowHandle};
-                    winit::window::WindowBuilder::new()
+                    use winit::raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+                    match winit::window::WindowBuilder::new()
                         .with_decorations(false)
                         .with_visible(false)
                         .with_title("OMPL Media Control Window")
                         .build(&winit::event_loop::EventLoop::new().unwrap())
                         .unwrap()
-                        .window_handle()
-                        .ok()
-                        .map(|h| match h.as_raw() {
-                            RawWindowHandle::Win32(wh) => {
-                                let p: *mut isize = &mut wh.hwnd.get();
-                                Some(p.cast())
-                            }
-                            _ => None,
-                        })
-                        .flatten()
+                        .raw_window_handle()
+                    {
+                        RawWindowHandle::Win32(han) => Some(han.hwnd),
+                        _ => panic!("Unknown window handle type!"),
+                    }
                 };
 
                 match MediaControls::new(PlatformConfig {

--- a/src/main.rs
+++ b/src/main.rs
@@ -814,7 +814,7 @@ fn instance_main(listener: TcpListener, args: Args) {
                     // You *could* use winapi::um::wincon::GetConsoleWindow()
                     // but if you're running ompl from the CLI, conhost.exe will own the window process
                     // so souvlaki can't hook into it. This just creates a hidden window instead.
-                    use winit::raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+                    use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
                     match winit::window::WindowBuilder::new()
                         .with_decorations(false)
                         .with_visible(false)


### PR DESCRIPTION
Revert main to use old rwh code. Souvlaki doesn't like the new value, probably because the NonZeroIsize is copied.